### PR TITLE
Fix error when byte-compiling

### DIFF
--- a/cargo-transient.el
+++ b/cargo-transient.el
@@ -52,18 +52,19 @@ It is equivalent to `project-compilation-buffer-name-function'."
 
 ;; Group Names
 
-(defconst cargo-transient--group-target-selection
-  "Target Selection")
-(defconst cargo-transient--group-feature-selection
-  "Feature Selection")
-(defconst cargo-transient--group-compilation-options
-  "Compilation Options")
-(defconst cargo-transient--group-manifest-options
-  "Manifest Options")
-(defconst cargo-transient--group-arguments
-  "Arguments")
-(defconst cargo-transient--group-actions
-  "Actions")
+(eval-when-compile
+  (defconst cargo-transient--group-target-selection
+    "Target Selection")
+  (defconst cargo-transient--group-feature-selection
+    "Feature Selection")
+  (defconst cargo-transient--group-compilation-options
+    "Compilation Options")
+  (defconst cargo-transient--group-manifest-options
+    "Manifest Options")
+  (defconst cargo-transient--group-arguments
+    "Arguments")
+  (defconst cargo-transient--group-actions
+    "Actions"))
 
 ;; Transients
 


### PR DESCRIPTION
I'm not familiar with `eval-when-compile`, but my understanding here is that `cargo-transient--group-[*]` need to be computed at compile-time because they are used in the uses of the `transient-define-prefix` macros, which are themselves evaluated at compile-time.

Fix #18