### PR TITLE
Always run `cargo` from the `default-directory`

### DIFF
--- a/cargo-transient.el
+++ b/cargo-transient.el
@@ -455,8 +455,6 @@ arguments."
   "Run `cargo COMMAND ARGS'."
   (let* ((cargo-args        (if args (mapconcat #'identity args " ") ""))
          (command           (format "cargo %s %s" command cargo-args))
-         (project           (project-current))
-         (default-directory (if project (project-root project) default-directory))
          (compilation-buffer-name-function (or cargo-transient-compilation-buffer-name-function
                                                compilation-buffer-name-function)))
     (compile command)))


### PR DESCRIPTION
`cargo` will traverse directories upwards until it finds a `Cargo.toml` file, so running it from `default-directory` handles cases where the `Cargo.toml` file is not at the project root.