### PR TITLE
Replace use of `project-prefixed-buffer-name` with a custom function

### DIFF
--- a/cargo-transient.el
+++ b/cargo-transient.el
@@ -70,8 +70,13 @@ It is equivalent to `project-compilation-buffer-name-function'."
   :group 'cargo-transient
   :type '(choice (const :tag "Default" nil)
                  (const :tag "Prefixed with root directory name"
-                        project-prefixed-buffer-name)
+                        cargo-transient-project-prefixed-buffer-name)
                  (function :tag "Custom function")))
+
+(defun cargo-transient-project-prefixed-buffer-name (mode)
+  (let* ((project           (project-current))
+         (default-directory (if project (project-root project) default-directory)))
+    (project-prefixed-buffer-name mode)))
 
 ;; Group Names
 


### PR DESCRIPTION
An unintended consequence of 69b56ef was that `project-prefixed-buffer-name` no longer worked as intended as the value of `cargo-transient-compilation-buffer-name-function`, because it relies on `default-directory` being set to the project root.

This commit replaces it as an option for `cargo-transient-compilation-buffer-name-function` with a wrapped version, specific to cargo-transient, which sets `default-directory` before calling `project-prefixed-buffer-name` if it is run in the context of a project.