### PR TITLE
Run cargo from the directory containing Cargo.toml

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
-      with: { python-version: 3.6 }
+      with: { python-version: 3.11 }
     - name: Install
       run: |
         python -m pip install --upgrade pip

--- a/cargo-transient.el
+++ b/cargo-transient.el
@@ -461,7 +461,9 @@ arguments."
   (let* ((cargo-args        (if args (mapconcat #'identity args " ") ""))
          (command           (format "cargo %s %s" command cargo-args))
          (compilation-buffer-name-function (or cargo-transient-compilation-buffer-name-function
-                                               compilation-buffer-name-function)))
+                                               compilation-buffer-name-function))
+         (default-directory (or (locate-dominating-file default-directory "Cargo.toml")
+                                default-directory)))
     (compile command)))
 
 (provide 'cargo-transient)


### PR DESCRIPTION
... if it can be located.  Otherwise use the current value of `default-directory`, although it seems very unlikely that any cargo commands would succeed in that case.

This improves on 69b56ef while retaining the same functionality. Previously, cargo itself would look for Cargo.toml in parent directories, but the compilation buffer was not able to open files referenced in error messages because their paths were relative to the Cargo.toml file, not the `default-directory` of the compilation buffer.

Close #32